### PR TITLE
Fix RSS build error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-feed'

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,9 @@ paginate_path: /:num
 timezone: America/New_York
 permalink: /:slug
 
+author:
+  twitter: shawnajeanr
+
 site_heading: >
     me<span class="faded">.shawna jean</span>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,8 +12,9 @@
   <link href="https://fonts.googleapis.com/css?family=Dosis:300" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Cutive+Mono" rel="stylesheet">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-
+  
+  {% feed_meta %}
+  
   <!-- Sharing buttons -->
   <script type='text/javascript' data-cfasync='false' src='//dsms0mj1bbhn4.cloudfront.net/assets/pub/shareaholic.js' data-shr-siteid='5a298c94c27993da4240c3cf5fcf9437' async='async'></script>
 


### PR DESCRIPTION
> The value 'nil' was passed to a date-related filter that expects valid dates in `feed.xml` or one of its layouts. For more information, see https://help.github.com/articles/page-build-failed-date-is-not-a-valid-datetime/.
